### PR TITLE
Fix building with system wide qt-openzwave

### DIFF
--- a/ozw-admin.pri
+++ b/ozw-admin.pri
@@ -117,13 +117,13 @@ unix {
     		INCLUDEPATH+=$$QTOZW_INCLUDE_PATH
     		LIBS+=$$QTOZW_LIBS
 	} else {
-		packagesExist("libqt-openzwave") {
-			PKGCONFIG += libqt-openzwave
+		packagesExist("qt-openzwave") {
+			PKGCONFIG += qt-openzwave
 	    		message(" ")
     			message("QT-OpenZWave Summary:")
 			message("	Using QT-OpenZWave from pkg-config:")
-			message("	CXXFLAGS: $$system($$PKG_CONFIG --cflags libqt-openzwave)")
-			message("	LDFLAGS: $$system($$PKG_CONFIG --libs libqt-openzwave)")
+			message("	CXXFLAGS: $$system($$PKG_CONFIG --cflags qt-openzwave)")
+			message("	LDFLAGS: $$system($$PKG_CONFIG --libs qt-openzwave)")
 			message(" ")
 		} else {
 			error("Can't find QT-OpenZWave Library and Headers");

--- a/ozwadmin-main/ozwadmin-main.pro
+++ b/ozwadmin-main/ozwadmin-main.pro
@@ -66,7 +66,7 @@ include(../ozw-admin.pri)
 unix {
     target.path = /usr/local/bin
     INSTALLS += target
-    LIBS += -L../devicedb-lib/ -ldevicedb-lib -L../ozwadmin-widgets/ -lozwadmin-widgets
+    LIBS += -L../devicedb-lib/ -ldevicedb-lib -L../ozwadmin-widgets/ -lozwadmin-widgets -lqt-openzwavedatabase
 }
 windows {
     CONFIG(debug, debug|release) {


### PR DESCRIPTION
As there's currently no pkg-config file for openzwavedatabase explicitly linking to it is required.

With this change it's now possible to compile/link ozw-admin with a system wide qt-openzwave installation, and install it. There are some issues related to locating database files at startup, but I've seen similar with an ozw-admin started in-tree. One minor issue left is that binaries end up in /usr/local/bin per default.